### PR TITLE
Avoid scrollbars in Chrome

### DIFF
--- a/client/src/index.html.js
+++ b/client/src/index.html.js
@@ -24,7 +24,9 @@ export default function({ htmlWebpackPlugin }) {
           body, #root {
             width: 100%;
             height: 100%;
+            overflow: hidden;
             margin: 0;
+            padding: 0;
             background: #E64369;
           }
         </style>


### PR DESCRIPTION
Add `overflow: hidden;` to avoid scrollbars popping up in Chrome, and also reset `padding` for good measure.